### PR TITLE
Catch URIError Exceptions on Malformed URI Sequences

### DIFF
--- a/src/jstiller.js
+++ b/src/jstiller.js
@@ -1609,9 +1609,11 @@ var jstiller = (function() {
               type: 'Identifier',
               name: realCallee.name
             }) && ret.purearg) {
-            value = global[realCallee.name].apply(null,
-              ret.arguments.map(getValue));
-            return mkliteral(value);
+            try {
+              value = global[realCallee.name].apply(null,
+                ret.arguments.map(getValue));
+              return mkliteral(value);
+            } catch (e) {}
           }
         }
 

--- a/tests/tests_OK/URIError.js
+++ b/tests/tests_OK/URIError.js
@@ -1,0 +1,1 @@
+eval(String.fromCharCode(97,108,101,114,116))(1);decodeURIComponent('%xx');

--- a/tests/tests_OK/expected_acc/URIError.js
+++ b/tests/tests_OK/expected_acc/URIError.js
@@ -1,0 +1,2 @@
+alert;(1);
+decodeURIComponent('%xx');


### PR DESCRIPTION
Hey @wisec,

Malformed URI sequences can cause the `decodeURI` and `decodeURIComponent` functions to throw a `URIError` exception. This causes the entire deobfuscation attempt to fail as a result:
```
$ ./jstillery_cli.js obfuscated.js
URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at ast_reduce ([REDACTED]/src/jstiller.js:1612:45)
    at ast_reduce_scoped ([REDACTED]/src/jstiller.js:840:14)
    at ast_reduce ([REDACTED]/src/jstiller.js:1098:23)
    at ast_reduce_scoped ([REDACTED]/src/jstiller.js:840:14)
    at Array.map (<anonymous>)
    at Object.ast_reduce [as deobfuscate] ([REDACTED]/src/jstiller.js:1091:26)
    at Object.<anonymous> ([REDACTED]/jstillery_cli.js:61:16)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
Original:
====================
eval(String.fromCharCode(97,108,101,114,116))(1);decodeURIComponent('%xx');

====================
____________________
Deobfuscated Code
eval(String.fromCharCode(97, 108, 101, 114, 116))(1);
decodeURIComponent('%xx');
```

The output after the fix is:
```
Original:
====================
eval(String.fromCharCode(97,108,101,114,116))(1);decodeURIComponent('%xx');

====================
____________________
Deobfuscated Code
alert;(1);
decodeURIComponent('%xx');
```

Cheers!